### PR TITLE
Fix security vulnerability by replacing e.printStackTrace() with Logger.logError()

### DIFF
--- a/robocode.repository/src/main/java/net/sf/robocode/repository/root/handlers/JarHandler.java
+++ b/robocode.repository/src/main/java/net/sf/robocode/repository/root/handlers/JarHandler.java
@@ -45,7 +45,7 @@ public class JarHandler extends RootHandler {
 				try {
 					key = "jar:" + jar.toURI().toURL() + "!/";
 				} catch (MalformedURLException e) {
-					e.printStackTrace();
+					Logger.logError("An error occurred: " + e.getMessage());
 					continue;
 				}
 				IRepositoryRoot root = repository.getRoots().get(key);


### PR DESCRIPTION
Resolves #4 

**Description**
e.printStackTrace() will reveal sensitive system security information such as file path, project structure, underlying framework, sensitive configuration data, internal logic, and error handling. This can result in security vulnerability as logs contain sensitive information about the project. To resolve this issue, printing self-explaining error messages rather than revealing system-sensitive information. 

**Path of file having the issue:**
robocode.repository/src/main/java/net/sf/robocode/repository/root/handlers/JarHandler.java

**Link to the issue:**
[Link of issue #4]