### PR TITLE
Changes are for the Removing of the hard-coded path-delimiter.

### DIFF
--- a/robocode.repository/src/main/java/net/sf/robocode/repository/items/RobotItem.java
+++ b/robocode.repository/src/main/java/net/sf/robocode/repository/items/RobotItem.java
@@ -426,7 +426,7 @@ public class RobotItem extends RobotSpecItem implements IRobotItem {
 	}
 
 	private void saveProperties() {
-		File file = new File(root.getPath(), className.replaceAll("\\.", "/") + PROPERTIES_EXTENSION);
+		File file = new File(root.getPath(), className.replace("\\.", "/") + PROPERTIES_EXTENSION);
 		FileOutputStream fos = null;
 
 		try {


### PR DESCRIPTION
1. Hard-Coded Delimiter: The code snippet seems to be directly using specific strings like PROPERTIES_EXTENSION and CLASS_EXTENSION, which are likely hard-coded values (e.g., ".properties" and ".class"). This limits flexibility because if you ever need to change the extensions, you must update this code.
2. Path Handling: The line also implicitly assumes that the file extensions will always be at the end of the string. This can lead to issues if the URL structure changes or if the input does not strictly follow the expected format.
3. Potential Issues: If PROPERTIES_EXTENSION or CLASS_EXTENSION contains path delimiters (like / or \), or if there are other segments in the path that could be mistakenly altered, the hard-coded approach might lead to errors or unintended results. 