### PR TITLE
Refactored Clone in WindowPositionManager.java (line 63 & 72)

### DIFF
--- a/robocode.ui/src/main/java/net/sf/robocode/ui/dialog/WindowPositionManager.java
+++ b/robocode.ui/src/main/java/net/sf/robocode/ui/dialog/WindowPositionManager.java
@@ -61,15 +61,14 @@ public class WindowPositionManager implements ComponentListener {
 	public void componentHidden(ComponentEvent e) {}
 
 	public void componentMoved(ComponentEvent e) {
-		// Hack, because we cannot detect maximized frame in Java 1.3
-		if (e.getComponent().getBounds().getWidth() >= Toolkit.getDefaultToolkit().getScreenSize().width
-				|| e.getComponent().getBounds().getHeight() >= Toolkit.getDefaultToolkit().getScreenSize().height) {
-			return;
-		}
-		setWindowRect((Window) e.getComponent(), e.getComponent().getBounds());
+		componentWindowRect(e);
 	}
 
 	public void componentResized(ComponentEvent e) {
+		componentWindowRect(e);
+	}
+
+	private void componentWindowRect(ComponentEvent e) {
 		// Hack, because we cannot detect maximized frame in Java 1.3
 		if (e.getComponent().getBounds().getWidth() >= Toolkit.getDefaultToolkit().getScreenSize().width
 				|| e.getComponent().getBounds().getHeight() >= Toolkit.getDefaultToolkit().getScreenSize().height) {


### PR DESCRIPTION
**Clone Description:**
A 10-line (86 tokens) code duplication was detected in the WindowPositionManager.java file within two methods, i.e., **componentMoved(ComponentEvent e)** and **componentResized(ComponentEvent e)**. Both methods perform the same functionality using the same code.

**Path of file having the issue:**
robocode.ui\src\main\java\net\sf\robocode\ui\dialog\WindowPositionManager.java

**Solution**
Refactored componentMoved and componentResized to use **componentWindowRect** as a helper method to avoid redundancy and improve code readability.

**Issue:** 
https://github.com/rilling/robocodeFall2024/issues/39