### PR TITLE
Refactor getReadableDirectory() and getWritableDirectory() to eliminate Code Duplication.

### DIFF
--- a/robocode.repository/src/main/java/net/sf/robocode/repository/items/RobotItem.java
+++ b/robocode.repository/src/main/java/net/sf/robocode/repository/items/RobotItem.java
@@ -549,40 +549,35 @@ public class RobotItem extends RobotSpecItem implements IRobotItem {
 	}
 
 	public String getReadableDirectory() {
-		String path;
-		if (root.isJAR()) {
-			String jarFile = getClassPathURL().getFile();
-			jarFile = jarFile.substring(jarFile.lastIndexOf('/') + 1);
-			path = FileUtil.getRobotsDataDir().getPath();
-			if (jarFile.length() > 0) {
-				path += File.separator + jarFile + '_';
-			}
-		} else {
-			path = getClassPathURL().getFile();
-		}
-		if (getFullPackage() != null) {
-			path += File.separator + getFullPackage().replace('.', File.separatorChar);
-		}
-		return path;
+		String path = root.isJAR() ? getJarPath() : getNonJarPath(false);
+        return appendPackagePath(path);
 	}
 
 	public String getWritableDirectory() {
-		String path;
-		if (root.isJAR()) {
-			String jarFile = getClassPathURL().getFile();	
-			jarFile = jarFile.substring(jarFile.lastIndexOf('/') + 1);
-			path = FileUtil.getRobotsDataDir().getPath();
-			if (jarFile.length() > 0) {
-				path += File.separator + jarFile + '_';
-			}
-		} else {
-			path = ALWAYS_USE_CACHE_FOR_DATA ? FileUtil.getRobotsDataDir().getPath() : getClassPathURL().getFile();
-		}
-		if (getFullPackage() != null) {
-			path += File.separator + getFullPackage().replace('.', File.separatorChar);
-		}
-		return path;
+		String path = root.isJAR() ? getJarPath() : getNonJarPath(ALWAYS_USE_CACHE_FOR_DATA);
+        return appendPackagePath(path);
 	}
+
+	private String getJarPath() {
+        String jarFile = getClassPathURL().getFile();
+        jarFile = jarFile.substring(jarFile.lastIndexOf('/') + 1);
+        String path = FileUtil.getRobotsDataDir().getPath();
+        if (jarFile.length() > 0) {
+            path += File.separator + jarFile + '_';
+        }
+        return path;
+    }
+
+	private String getNonJarPath(boolean useCache) {
+        return useCache ? FileUtil.getRobotsDataDir().getPath() : getClassPathURL().getFile();
+    }
+
+	private String appendPackagePath(String path) {
+        if (getFullPackage() != null) {
+            path += File.separator + getFullPackage().replace('.', File.separatorChar);
+        }
+        return path;
+    }
 
 	public RobotSpecification createRobotSpecification(RobotSpecification battleRobotSpec, String teamName) {
 		RobotSpecification specification;


### PR DESCRIPTION
**Description -**
This pull request refactors the getReadableDirectory() and getWritableDirectory() methods by extracting common logic into helper methods. The changes improve code maintainability and readability by removing redundancy and simplifying the methods:
Introduced helper methods: getJarPath(), getNonJarPath(boolean useCache), and appendPackagePath(String path).
Both getReadableDirectory() and getWritableDirectory() now leverage these helper methods to construct the appropriate directory paths.

**File Path :** robocode.repository/src/main/java/net/sf/robocode/repository/items/RobotItem.java

**Issue:** [rilling#43](https://github.com/rilling/robocodeFall2024/issues/43)