### PR TITLE
Fixed MET03 vulnerability in checkAccess method

### DIFF
--- a/robocode.host/src/main/java/net/sf/robocode/host/security/RobocodeSecurityManager.java
+++ b/robocode.host/src/main/java/net/sf/robocode/host/security/RobocodeSecurityManager.java
@@ -42,7 +42,7 @@ public class RobocodeSecurityManager extends SecurityManager {
 	}
 
 	@Override
-	public void checkAccess(Thread t) {
+	public final void checkAccess(Thread t) {
 		Thread c = Thread.currentThread();
 		if (isSafeThread(c)) {
 			return;
@@ -83,7 +83,7 @@ public class RobocodeSecurityManager extends SecurityManager {
 	}
 
 	@Override
-	public void checkAccess(ThreadGroup g) {
+	public final void checkAccess(ThreadGroup g) {
 		Thread c = Thread.currentThread();
 		if (isSafeThread(c)) {
 			return;


### PR DESCRIPTION
**Description:**
This PR addresses a security vulnerability in the **checkAccess(ThreadGroup g)** method. Previously, the method was neither private nor final, making it susceptible to being overridden by malicious subclasses. This posed a risk of bypassing the critical security checks implemented in the method, violating [SEI CERT rule MET03-J](https://wiki.sei.cmu.edu/confluence/display/java/MET03-J.+Methods+that+perform+a+security+check+must+be+declared+private+or+final).


**Solution**
The issue is mitigated by declaring the checkAccess(ThreadGroup g) method as final. This change ensures that the method cannot be overridden, safeguarding the security checks from being bypassed or tampered with. By doing so, the integrity of access control mechanisms is preserved, and the implementation aligns with secure coding practices to prevent unauthorized access or malicious exploitation.


**File Path**
robocodeFall2024\robocode.host\src\main\java\net\sf\robocode\host\security\RobocodeSecurityManager.java

**Issue**
https://github.com/rilling/robocodeFall2024/issues/80