### PR TITLE
sri-casestudy-3

### DIFF
--- a/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
+++ b/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
@@ -1,97 +1,25 @@
-import net.sf.robocode.io.FileUtil;
-import net.sf.robocode.io.Logger;
-import net.sf.robocode.io.URLJarCollector;
+public static void extractFile(File dest, JarInputStream jarIS, JarEntry entry) throws IOException {
+	// Get the destination directory path
+	File out = new File(dest, entry.getName());
 
-import java.io.*;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.jar.JarInputStream;
-import java.util.jar.JarEntry;
-import java.net.URLConnection;
-import java.net.URL;
-
-public class JarExtractor {
-
-	// Helper method to create parent directories
-	private static void ensureParentDirectoryExists(File file) {
-		File parentDirectory = new File(file.getParent());
-		if (!parentDirectory.exists() && !parentDirectory.mkdirs()) {
-			Logger.logError("Cannot create parent dir: " + parentDirectory);
-		}
+	// Prevent path traversal by sanitizing the file path
+	// Normalize the file path to avoid directory traversal (e.g., ../ or absolute paths)
+	if (!out.getCanonicalPath().startsWith(dest.getCanonicalPath())) {
+		Logger.logError("Blocked path traversal attempt: " + entry.getName());
+		throw new IOException("Path traversal detected: " + entry.getName());
 	}
 
-	public static void extractJar(URL url) {
-		File dest = FileUtil.getRobotsDir();
-		InputStream is = null;
-		BufferedInputStream bis = null;
-		JarInputStream jarIS = null;
+	// Ensure the parent directory exists
+	ensureParentDirectoryExists(out);
 
-		try {
-			if (dest == null || !dest.exists()) {
-				Logger.logError("Destination directory is invalid: " + dest);
-				return;
-			}
+	// Open streams to write the file contents
+	try (FileOutputStream fos = new FileOutputStream(out);
+		 BufferedOutputStream bos = new BufferedOutputStream(fos)) {
 
-			final URLConnection con = URLJarCollector.openConnection(url);
-			is = con.getInputStream();
-			bis = new BufferedInputStream(is);
-			jarIS = new JarInputStream(bis);
-
-			JarEntry entry = jarIS.getNextJarEntry();
-			while (entry != null) {
-				if (entry.isDirectory()) {
-					File dir = new File(dest, entry.getName());
-					ensureParentDirectoryExists(dir);
-				} else {
-					extractFile(dest, jarIS, entry); // Process files using the existing extractFile method
-				}
-				entry = jarIS.getNextJarEntry();
-			}
-		} catch (IOException e) {
-			Logger.logError("Error while extracting jar: " + e.getMessage());
-			e.printStackTrace();
-		} finally {
-			FileUtil.cleanupStream(jarIS);
-			FileUtil.cleanupStream(bis);
-			FileUtil.cleanupStream(is);
-		}
-	}
-
-	public static void extractFile(File dest, JarInputStream jarIS, JarEntry entry) throws IOException {
-		// Get the file path from the jar entry
-		File out = new File(dest, entry.getName());
-
-		// Normalize and validate the file path to prevent path traversal
-		Path destPath = dest.getCanonicalFile().toPath();
-		Path outPath = destPath.resolve(entry.getName()).normalize();
-
-		// Ensure that the file is inside the intended destination directory
-		if (!outPath.startsWith(destPath)) {
-			Logger.logError("Invalid file entry (path traversal attempt): " + entry.getName());
-			throw new IOException("Invalid file entry: " + entry.getName());
-		}
-
-		// Ensure parent directories exist
-		ensureParentDirectoryExists(out);
-
-		FileOutputStream fos = null;
-		BufferedOutputStream bos = null;
 		byte[] buf = new byte[2048];
-
-		try {
-			fos = new FileOutputStream(out);
-			bos = new BufferedOutputStream(fos);
-
-			int num;
-			while ((num = jarIS.read(buf, 0, 2048)) != -1) {
-				bos.write(buf, 0, num);
-			}
-		} catch (IOException e) {
-			Logger.logError("Error writing file: " + e.getMessage());
-			throw e;
-		} finally {
-			FileUtil.cleanupStream(bos);
-			FileUtil.cleanupStream(fos);
+		int num;
+		while ((num = jarIS.read(buf, 0, 2048)) != -1) {
+			bos.write(buf, 0, num);
 		}
 	}
 }

--- a/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
+++ b/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
@@ -9,8 +9,8 @@ public static void extractFile(File dest, JarInputStream jarIS, JarEntry entry) 
 		throw new IOException("Path traversal detected: " + entry.getName());
 	}
 
-	// Ensure the parent directory exists
-	ensureParentDirectoryExists(out);
+	// Ensure the parent directory exist
+	ensureParentDirectoryExists(out)
 
 	// Open streams to write the file contents
 	try (FileOutputStream fos = new FileOutputStream(out);

--- a/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
+++ b/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
@@ -1,25 +1,91 @@
-public static void extractFile(File dest, JarInputStream jarIS, JarEntry entry) throws IOException {
-	// Get the destination directory path
-	File out = new File(dest, entry.getName());
 
-	// Prevent path traversal by sanitizing the file path
-	// Normalize the file path to avoid directory traversal (e.g., ../ or absolute paths)
-	if (!out.getCanonicalPath().startsWith(dest.getCanonicalPath())) {
-		Logger.logError("Blocked path traversal attempt: " + entry.getName());
-		throw new IOException("Path traversal detected: " + entry.getName());
-	}
+package net.sf.robocode.repository.packager;
 
-	// Ensure the parent directory exist
-	ensureParentDirectoryExists(out)
+import net.sf.robocode.io.FileUtil;
+import net.sf.robocode.io.Logger;
+import net.sf.robocode.io.URLJarCollector;
 
-	// Open streams to write the file contents
-	try (FileOutputStream fos = new FileOutputStream(out);
-		 BufferedOutputStream bos = new BufferedOutputStream(fos)) {
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.FileOutputStream;
+import java.util.jar.JarInputStream;
+import java.util.jar.JarEntry;
+import java.net.URLConnection;
+import java.net.URL;
 
-		byte[] buf = new byte[2048];
-		int num;
-		while ((num = jarIS.read(buf, 0, 2048)) != -1) {
-			bos.write(buf, 0, num);
+public class JarExtractor {
+
+	// Helper method to create parent directories
+	private static void ensureParentDirectoryExists(File file) {
+		File parentDirectory = new File(file.getParent());
+		if (!parentDirectory.exists() && !parentDirectory.mkdirs()) {
+			Logger.logError("Cannot create parent dir: " + parentDirectory);
 		}
 	}
+
+	public static void extractJar(URL url) {
+		File dest = FileUtil.getRobotsDir();
+		InputStream is = null;
+		BufferedInputStream bis = null;
+		JarInputStream jarIS = null;
+
+		try {
+			final URLConnection con = URLJarCollector.openConnection(url);
+
+			is = con.getInputStream();
+			bis = new BufferedInputStream(is);
+			jarIS = new JarInputStream(bis);
+
+			JarEntry entry = jarIS.getNextJarEntry();
+
+			while (entry != null) {
+				if (entry.isDirectory()) {
+					File dir = new File(dest, entry.getName());
+					// Use the helper method to create the parent directory
+					ensureParentDirectoryExists(dir);
+				} else {
+					extractFile(dest, jarIS, entry); // Process files using the existing extractFile method
+				}
+				entry = jarIS.getNextJarEntry();
+			}
+		} catch (IOException e) {
+			Logger.logError(e);
+		} finally {
+			FileUtil.cleanupStream(jarIS);
+			FileUtil.cleanupStream(bis);
+			FileUtil.cleanupStream(is);
+		}
+	}
+
+	public static void extractFile(File dest, JarInputStream jarIS, JarEntry entry) throws IOException {
+		// Create the file to be written to
+		File out = new File(dest, entry.getName());
+
+		// Sanitize the path to prevent directory traversal
+		// Ensure the file is within the destination directory
+		if (!out.getCanonicalPath().startsWith(dest.getCanonicalPath())) {
+			Logger.logError("Blocked path traversal attempt: " + entry.getName());
+			throw new IOException("Path traversal detected: " + entry.getName());
+		}
+
+		// Ensure the parent directory exists
+		ensureParentDirectoryExists(out);
+
+		try (FileOutputStream fos = new FileOutputStream(out);
+			 BufferedOutputStream bos = new BufferedOutputStream(fos)) {
+
+			byte[] buf = new byte[2048];
+			int num;
+			while ((num = jarIS.read(buf, 0, 2048)) != -1) {
+				bos.write(buf, 0, num);
+			}
+		} catch (IOException e) {
+			Logger.logError("Error writing file: " + out.getAbsolutePath(), e);
+			throw e;
+		}
+	}
+
 }

--- a/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
+++ b/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
@@ -63,7 +63,7 @@ public class JarExtractor {
 		// Get the file path from the jar entry
 		File out = new File(dest, entry.getName());
 
-		// Normalize and validate the file path to prevent path traversal
+		// Normalize and validate  file path to prevent path traversal
 		Path destPath = dest.getCanonicalFile().toPath();
 		Path outPath = destPath.resolve(entry.getName()).normalize();
 

--- a/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
+++ b/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
@@ -1,5 +1,3 @@
-package net.sf.robocode.repository.packager;
-
 import net.sf.robocode.io.FileUtil;
 import net.sf.robocode.io.Logger;
 import net.sf.robocode.io.URLJarCollector;
@@ -10,6 +8,8 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.FileOutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.jar.JarInputStream;
 import java.util.jar.JarEntry;
 import java.net.URLConnection;
@@ -60,9 +60,19 @@ public class JarExtractor {
 	}
 
 	public static void extractFile(File dest, JarInputStream jarIS, JarEntry entry) throws IOException {
+		// Get the file path from the jar entry
 		File out = new File(dest, entry.getName());
 
-		// Use the helper method to create the parent directory
+		// Normalize and validate the file path to prevent path traversal
+		Path destPath = dest.getCanonicalFile().toPath();
+		Path outPath = destPath.resolve(entry.getName()).normalize();
+
+		// Ensure that the file is inside the intended destination directory
+		if (!outPath.startsWith(destPath)) {
+			throw new IOException("Invalid file entry: " + entry.getName());
+		}
+
+		// Ensure parent directories exist
 		ensureParentDirectoryExists(out);
 
 		FileOutputStream fos = null;

--- a/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
+++ b/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
@@ -70,7 +70,6 @@ public class JarExtractor {
 			Logger.logError("Blocked path traversal attempt: " + entry.getName());
 			throw new IOException("Path traversal detected: " + entry.getName());
 		}
-
 		// Ensure the parent directory exists
 		ensureParentDirectoryExists(out);
 


### PR DESCRIPTION
Path Traversal Vulnerability: By resolving the file paths with normalize() and validating that the resulting path is inside the intended destination directory (dest), this fix prevents any files from being extracted outside the allowed directory, even if the JAR contains malicious paths.